### PR TITLE
Slider+select components in projection explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@didyoumeantoast/dash-components": "^1.5.5",
-    "@didyoumeantoast/dash-components-react": "^1.5.5",
+    "@didyoumeantoast/dash-components": "^1.8.1",
+    "@didyoumeantoast/dash-components-react": "^1.8.1",
     "@mdx-js/react": "^2.2.1",
     "@mdx-js/rollup": "^2.2.1",
     "d3": "^7.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@didyoumeantoast/dash-components': ^1.5.5
-  '@didyoumeantoast/dash-components-react': ^1.5.5
+  '@didyoumeantoast/dash-components': ^1.8.1
+  '@didyoumeantoast/dash-components-react': ^1.8.1
   '@mdx-js/react': ^2.2.1
   '@mdx-js/rollup': ^2.2.1
   '@types/react': ^18.0.27
@@ -19,8 +19,8 @@ specifiers:
   vite-plugin-static-copy: ^0.15.0
 
 dependencies:
-  '@didyoumeantoast/dash-components': 1.5.5
-  '@didyoumeantoast/dash-components-react': 1.5.5_biqbaboplfbrettd7655fr4n2y
+  '@didyoumeantoast/dash-components': 1.8.1
+  '@didyoumeantoast/dash-components-react': 1.8.1_biqbaboplfbrettd7655fr4n2y
   '@mdx-js/react': 2.3.0_react@18.2.0
   '@mdx-js/rollup': 2.3.0_rollup@2.79.1
   d3: 7.8.4
@@ -272,19 +272,19 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@didyoumeantoast/dash-components-react/1.5.5_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-hgYRjq48k4kYbYObcdQ4c+qhfauhOIsZnBmlTIjlwMlmNSjH3vuoiLfTCCysw6gm6dw8YXerNfrPYAuhMhgvsw==}
+  /@didyoumeantoast/dash-components-react/1.8.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-M6B9Ygq+Tm12cIpELYPVPyvTVh0czpNeD9grdKWfI1OrSSyE3sTvXdSAiyPGZLppmFCPa+wj2xRssB8SpAxaIA==}
     peerDependencies:
       react: '>=16.4'
       react-dom: '>=16.4'
     dependencies:
-      '@didyoumeantoast/dash-components': 1.5.5
+      '@didyoumeantoast/dash-components': 1.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@didyoumeantoast/dash-components/1.5.5:
-    resolution: {integrity: sha512-Qstzc3K9NT3NJCpmYZ210Os+t+OwAf5J0h/5k2G+dGf0gceypXxy69gjX5m9u/nS/xjrUbL/pojzUk96BLZ7IQ==}
+  /@didyoumeantoast/dash-components/1.8.1:
+    resolution: {integrity: sha512-Y8k8t29Q6H8ARNOmvNiEHXBh1Pkkb4hY0yfh9iwwcObJMS7v9sw+3MFF1OkVi4fvIsy8qx1eAL7CF/9a9wmtSQ==}
     engines: {node: 18.x}
     dependencies:
       '@didyoumeantoast/dash-utils': 2.0.0

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -13,6 +13,7 @@ export default function Button({
   href,
   target,
   status,
+  endIcon,
 } = {}) {
   const isShadowAppearance = appearance === "shadow";
   appearance = isShadowAppearance ? null : appearance;
@@ -28,6 +29,7 @@ export default function Button({
       href={href}
       target={target}
       status={status}
+      endIcon={endIcon}
       onClick={(e) => {
         if (!disabled) {
           onClick?.(e);

--- a/src/components/Quiz/Quiz.jsx
+++ b/src/components/Quiz/Quiz.jsx
@@ -199,7 +199,11 @@ export default function Quiz({ questions } = {}) {
             placement="bottom-end"
             autoClose={true}
           >
-            <DashButton slot="dropdown-trigger" appearance="outline">
+            <DashButton
+              slot="dropdown-trigger"
+              appearance="outline"
+              endIcon="chevron-down"
+            >
               Q{currentQuestionIndex + 1}
             </DashButton>
 
@@ -287,10 +291,7 @@ export default function Quiz({ questions } = {}) {
                   Finish
                 </Button>
               ) : (
-                <Button
-                  appearance="outline"
-                  onClick={nextQuestion}
-                >
+                <Button appearance="outline" onClick={nextQuestion}>
                   Next
                 </Button>
               )}

--- a/src/components/Slider/Slider.css
+++ b/src/components/Slider/Slider.css
@@ -1,0 +1,12 @@
+.slider {
+  max-width: 300px;
+}
+
+.slider .slider-label-container {
+  display: flex;
+  align-items: center;
+}
+
+.slider .slider-label {
+  margin-inline-end: var(--dash-spacing-1);
+}

--- a/src/components/Slider/Slider.jsx
+++ b/src/components/Slider/Slider.jsx
@@ -1,0 +1,32 @@
+import { DashLabel, DashSlider } from "@didyoumeantoast/dash-components-react";
+import React from "react";
+import "./Slider.css";
+
+export default function Slider({
+  label,
+  value,
+  min,
+  max,
+  minLabelWidth,
+  maxLabelWidth,
+  onSliderValueChange,
+} = {}) {
+  return (
+    <DashLabel className="slider">
+      <div className="slider-label-container">
+        <span className="slider-label">{label}</span>
+        <span className="slider-value">({value})</span>
+      </div>
+      <DashSlider
+        value={value}
+        min={min}
+        max={max}
+        minLabelWidth={minLabelWidth}
+        maxLabelWidth={maxLabelWidth}
+        step={1}
+        minMaxLabelsVisible={true}
+        onDashSliderValueChanged={(e) => onSliderValueChange?.(e.target.value)}
+      ></DashSlider>
+    </DashLabel>
+  );
+}

--- a/src/maps/ProjectionExplorer.jsx
+++ b/src/maps/ProjectionExplorer.jsx
@@ -1,184 +1,175 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import * as d3 from "d3";
 
 import { useD3 } from "../hooks/useD3.jsx";
 
+import { DashSelect } from "@didyoumeantoast/dash-components-react";
+import Slider from "../components/Slider/Slider.jsx";
 import "../styles/projection.css";
 
+const DefaultProjection = "AzimuthalEqualArea";
+const ProjectionTypes = [
+  "Azimuthal Equal Area",
+  "Azimuthal Equidistant",
+  "Albers",
+  "Conic Conformal",
+  "Conic Equal Area",
+  "Conic Equidistant",
+  "Equirectangular",
+  "Mercator",
+  "TransverseMercator",
+  // What is transverse mercator for?
+];
+
+const Circles = [
+  [-135, 0],
+  [-90, 0],
+  [-45, 0],
+  [0, 0],
+  [45, 0],
+  [90, 0],
+  [135, 0],
+  [180, 0],
+  [0, -70],
+  [0, -35],
+  [0, 35],
+  [0, 70],
+  [180, -70],
+  [180, -35],
+  [180, 35],
+  [180, 70],
+];
+
+const GeoGenerator = d3.geoPath().projection(DefaultProjection);
+const Graticule = d3.geoGraticule();
+const GeoCircle = d3.geoCircle().radius(10).precision(1);
+
 export default function ProjectionExplorer() {
-  const ref = useD3((svg) => {
-    var geojson;
-    var projectionTypes = [
-      "Azimuthal Equal Area",
-      "Azimuthal Equidistant",
-      "Albers",
-      "Conic Conformal",
-      "Conic Equal Area",
-      "Conic Equidistant",
-      "Equirectangular",
-      "Mercator",
-      "TransverseMercator",
-      // What is transverse mercator for?
-    ];
-    var projection;
-    var geoGenerator = d3.geoPath().projection(projection);
-    var graticule = d3.geoGraticule();
-    var circles = [
-      [-135, 0],
-      [-90, 0],
-      [-45, 0],
-      [0, 0],
-      [45, 0],
-      [90, 0],
-      [135, 0],
-      [180, 0],
-      [0, -70],
-      [0, -35],
-      [0, 35],
-      [0, 70],
-      [180, -70],
-      [180, -35],
-      [180, 35],
-      [180, 70],
-    ];
-    var geoCircle = d3.geoCircle().radius(10).precision(1);
-    var state = {
-      type: "AzimuthalEqualArea",
-      scale: 120,
-      translateX: 450,
-      translateY: 250,
-      centerLon: 0,
-      centerLat: 0,
-      rotateLambda: 0.1,
-      rotatePhi: 0,
-      rotateGamma: 0,
-    };
+  const [geojson, setGeoJson] = useState(null);
+  let projection;
+  const [state, setState] = useState({
+    type: DefaultProjection,
+    scale: 120,
+    translateX: 450,
+    translateY: 250,
+    centerLon: 0,
+    centerLat: 0,
+    rotateLambda: 0.1,
+    rotatePhi: 0,
+    rotateGamma: 0,
+  });
 
-    function initMenu() {
-      d3.select(".menu")
-        .selectAll(".slider.item input")
-        .on("input", function (d) {
-          var attr = d3.select(this).attr("name");
-          state[attr] = this.value;
-          d3.select(this.parentNode.parentNode)
-            .select(".value")
-            .text(this.value);
-          update();
-        });
-      d3.select(".menu .projection-type select")
-        .on("change", function (d) {
-          state.type = this.options[this.selectedIndex].value;
-          update();
-        })
-        .selectAll("option")
-        .data(projectionTypes)
-        .enter()
-        .append("option")
-        .attr("value", function (d) {
-          return d;
-        })
-        .text(function (d) {
-          return d;
-        });
-    }
-
-    function update() {
-      // Update projection
-      projection = d3["geo" + state.type.replace(/\s/g, "")]();
-      geoGenerator.projection(projection);
-      projection
-        .scale(state.scale)
-        .translate([state.translateX, state.translateY])
-        .center([state.centerLon, state.centerLat])
-        .rotate([state.rotateLambda, state.rotatePhi, state.rotateGamma]); // Update world map
-
-      var u = d3.select("g.map").selectAll("path").data(geojson.features);
-      u.enter().append("path").merge(u).attr("d", geoGenerator); // Update projection center
-
-      var projectedCenter = projection([state.centerLon, state.centerLat]);
-      d3.select(".projection-center")
-        .attr("cx", projectedCenter[0])
-        .attr("cy", projectedCenter[1]); // Update graticule
-
-      d3.select(".graticule path").datum(graticule()).attr("d", geoGenerator); // Update circles
-
-      u = d3
-        .select(".circles")
-        .selectAll("path")
-        .data(
-          circles.map(function (d) {
-            geoCircle.center(d);
-            return geoCircle();
-          })
-        );
-      u.enter().append("path").merge(u).attr("d", geoGenerator);
-    }
-
+  useEffect(() => {
     d3.json(
       "https://gist.githubusercontent.com/d3indepth/f28e1c3a99ea6d84986f35ac8646fac7/raw/c58cede8dab4673c91a3db702d50f7447b373d98/ne_110m_land.json"
     ).then((json, err) => {
-      geojson = json;
-      initMenu();
-      update();
+      setGeoJson(json);
     });
-  });
+  }, []);
+
+  useEffect(() => {
+    update();
+  }, [state, geojson]);
+
+  function update() {
+    if (!geojson) {
+      return;
+    }
+
+    // Update projection
+    projection = d3["geo" + state.type.replace(/\s/g, "")]();
+    GeoGenerator.projection(projection);
+    projection
+      .scale(state.scale)
+      .translate([state.translateX, state.translateY])
+      .center([state.centerLon, state.centerLat])
+      .rotate([state.rotateLambda, state.rotatePhi, state.rotateGamma]); // Update world map
+
+    var u = d3.select("g.map").selectAll("path").data(geojson.features);
+    u.enter().append("path").merge(u).attr("d", GeoGenerator); // Update projection center
+
+    var projectedCenter = projection([state.centerLon, state.centerLat]);
+    d3.select(".projection-center")
+      .attr("cx", projectedCenter[0])
+      .attr("cy", projectedCenter[1]); // Update graticule
+
+    d3.select(".graticule path").datum(Graticule()).attr("d", GeoGenerator); // Update circles
+
+    u = d3
+      .select(".circles")
+      .selectAll("path")
+      .data(
+        Circles.map(function (d) {
+          GeoCircle.center(d);
+          return GeoCircle();
+        })
+      );
+    u.enter().append("path").merge(u).attr("d", GeoGenerator);
+  }
+
+  const ref = useD3(() => {});
 
   return (
     <>
       <div className="menu" style={{ margin: "inherit" }}>
         <div className="projection-type item">
-          <div>
-            <select name="type" defaultValue="150"></select>
+          <div style={{ maxWidth: "200px" }}>
+            <DashSelect
+              onDashSelectValueChange={(e) =>
+                setState({ ...state, type: e.detail })
+              }
+            >
+              {ProjectionTypes.map((type) => (
+                <option
+                  key={type}
+                  value={type}
+                  defaultValue={state.type === type}
+                >
+                  {type}
+                </option>
+              ))}
+            </DashSelect>
           </div>
         </div>
         <div className="slider item">
-          <div className="label">
-            Scale (<span className="value">120</span>)
-          </div>
-          <div>
-            <span className="low">0</span>{" "}
-            <input
-              type="range"
-              name="scale"
-              min="0"
-              max="400"
-              defaultValue="120"
-            />{" "}
-            <span>400</span>
-          </div>
+          <Slider
+            label="Scale"
+            value={state.scale}
+            min={0}
+            max={400}
+            minLabelWidth={30}
+            maxLabelWidth={30}
+            onSliderValueChange={(value) => {
+              setState({ ...state, scale: value });
+            }}
+          />
         </div>
         <div className="slider item">
-          <div className="label">
-            Center - Longitude (<span className="value">0</span>)
-          </div>
-          <div>
-            <span className="low">-180</span>{" "}
-            <input
-              type="range"
-              name="centerLon"
-              min="-180"
-              max="180"
-              defaultValue="0"
-            />{" "}
-            <span>180</span>
-          </div>
+          <Slider
+            label="Center - Longitude"
+            value={state.centerLon}
+            min={-180}
+            max={180}
+            minLabelWidth={30}
+            maxLabelWidth={30}
+            onSliderValueChange={(value) => {
+              setState({ ...state, centerLon: value });
+            }}
+          />
         </div>
         <div className="slider item">
-          <div className="label">
-            Center - Latitude (<span className="value">0</span>)
-          </div>
-          <div>
-            <span className="low">-90</span>{" "}
-            <input
-              type="range"
-              name="centerLat"
-              min="-90"
-              max="90"
-              defaultValue="0"
-            />{" "}
-            <span>90</span>
-          </div>
+          <Slider
+            label="Center - Latitude"
+            value={state.centerLat}
+            min={-90}
+            max={90}
+            minLabelWidth={30}
+            maxLabelWidth={30}
+            onSliderValueChange={(value) => {
+              setState({ ...state, centerLat: value });
+            }}
+          />
         </div>
         <svg
           ref={ref}


### PR DESCRIPTION
- Refactored the projection explorer to use `dash-slider` and `dash-select`. I also `reactified` the d3 code.
- Included a small change with the Quiz dropdown button in mobile to include a chevron.
